### PR TITLE
Pick an upper bound for the number of threads to use in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ Systems Diagram:
 Computation:
 
 Largest Prime Factor - The system will find the largest prime factor of the input number, for example, an input of '13195' would have an output of '5, 7, 13, 29'.
+
+
+Multi-threaded Implementation of NetworkAPI: 
+
+The upper bound for the number of threads is set to 10. This ensures efficient parallel execution without overwhelming system resources.
+The thread pool is managed using a fixed thread pool from ExecutorService, which means at most 10 requests can be processed concurrently.


### PR DESCRIPTION
Hi, I picked the upper bound for the number of threads to use in README. 